### PR TITLE
Fix Flakiness in testForkAndJoinWithThread()

### DIFF
--- a/cat-client/src/test/java/com/dianping/cat/message/MessageTest.java
+++ b/cat-client/src/test/java/com/dianping/cat/message/MessageTest.java
@@ -522,16 +522,17 @@ public class MessageTest extends ComponentTestCase {
 				@Override
 				public void run() {
 					ForkedTransaction forked = p.doFork();
-
-					try {
-						Transaction t = Cat.newTransaction("type", "child" + index);
-
-						Cat.logEvent("type", "name");
-						t.success();
-						t.complete();
-						latch.countDown();
-					} finally {
-						forked.close();
+					synchronized (p) {
+						try {
+							Transaction t = Cat.newTransaction("type", "child" + index);
+	
+							Cat.logEvent("type", "name");
+							t.success();
+							t.complete();
+							latch.countDown();
+						} finally {
+							forked.close();
+						}
 					}
 				}
 			}.start();


### PR DESCRIPTION
This pull request addresses and fixes the flakiness observed in the `testForkAndJoinWithThread()` method. The problem with this test is that in certain runs, it may result in `java.lang.AssertionError: 1 message ids should be used, but was 2!` due to the `checkMessageIdUsed(1)` line, which expects only one message ID, while two message IDs are being created. The flakiness of the test was observed using NonDex.

This error takes place due to multiple threads creating new message IDs concurrently. To fix this issue, I have added a `synchronized (p)` block, ensuring each thread works sequentially and creates only one message ID as expected.